### PR TITLE
allow passing arbitrary args

### DIFF
--- a/graal/graal.bzl
+++ b/graal/graal.bzl
@@ -14,6 +14,7 @@ def _graal_binary_implementation(ctx):
     args.add("-cp", ":".join([f.path for f in classpath_depset.to_list()]))
     args.add("-H:Class=%s" % ctx.attr.main_class)
     args.add("-H:Name=%s" % ctx.outputs.bin.path)
+    args.add_all(ctx.attr.args)
 
     if len(ctx.attr.native_image_features) > 0:
         args.add("-H:Features={entries}".format(entries=",".join(ctx.attr.native_image_features)))
@@ -64,4 +65,3 @@ graal_binary = rule(
     },
     executable = True,
 )
-


### PR DESCRIPTION
I wanted to pass extra flags like, but I only saw an attribute for passing "features". I couldn't find docs on that, so I just forwarded the default "args" attribute that the rule provides. This lets anyone add whatever extra config they need, without having to wait for specific support for it. Of course it's open ended and unsanitized input as well, so not sure it's the best idea.

```
"-H:EnableURLProtocols=http",
"--no-server",
"--no-fallback",
"-H:+ReportExceptionStackTraces",
```