### PR TITLE
Snoble/a few tweeks

### DIFF
--- a/graal/graal.bzl
+++ b/graal/graal.bzl
@@ -65,12 +65,19 @@ def _graal_binary_implementation(ctx):
     env = {}
     env["PATH"] = ctx.configuration.host_path_separator.join(paths)
 
+    binary = ctx.actions.declare_file("%s-bin" % ctx.attr.name)
+
     args = ctx.actions.args()
     args.add("--no-server")
+    args.add("--no-fallback")
     args.add("-cp", ":".join([f.path for f in classpath_depset.to_list()]))
     args.add("-H:Class=%s" % ctx.attr.main_class)
-    args.add("-H:Name=%s" % ctx.outputs.bin.path)
+    args.add("-H:Name=%s" % binary.path)
     args.add("-H:CCompilerPath=%s" % c_compiler_path)
+    args.add("-H:+ReportExceptionStackTraces")
+    args.add("--enable-http")
+    args.add("--enable-https")
+
 
     if len(ctx.attr.native_image_features) > 0:
         args.add("-H:Features={entries}".format(entries=",".join(ctx.attr.native_image_features)))
@@ -89,21 +96,22 @@ def _graal_binary_implementation(ctx):
 
     ctx.actions.run(
         inputs = classpath_depset,
-        outputs = [ctx.outputs.bin],
+        outputs = [binary],
         arguments = [args],
         executable = graal,
         env = env,
     )
 
     return [DefaultInfo(
-        executable = ctx.outputs.bin,
-        files = depset(),
+        executable = binary,
+        files = depset([binary]),
         runfiles = ctx.runfiles(
             collect_data = True,
             collect_default = True,
             files = [],
         ),
-    )]
+    )
+    ]
 
 graal_binary = rule(
     implementation = _graal_binary_implementation,
@@ -126,9 +134,6 @@ graal_binary = rule(
             default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")
         ),
         "data": attr.label_list(allow_files = True),
-    },
-    outputs = {
-        "bin": "%{name}-bin",
     },
     executable = True,
     fragments = ["cpp"],

--- a/graal/graal.bzl
+++ b/graal/graal.bzl
@@ -75,9 +75,8 @@ def _graal_binary_implementation(ctx):
     args.add("-H:Name=%s" % binary.path)
     args.add("-H:CCompilerPath=%s" % c_compiler_path)
     args.add("-H:+ReportExceptionStackTraces")
-    args.add("--enable-http")
-    args.add("--enable-https")
-
+    for arg in ctx.attr.graal_extra_args:
+        args.add(arg)
 
     if len(ctx.attr.native_image_features) > 0:
         args.add("-H:Features={entries}".format(entries=",".join(ctx.attr.native_image_features)))
@@ -110,8 +109,7 @@ def _graal_binary_implementation(ctx):
             collect_default = True,
             files = [],
         ),
-    )
-    ]
+    )]
 
 graal_binary = rule(
     implementation = _graal_binary_implementation,
@@ -134,6 +132,7 @@ graal_binary = rule(
             default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")
         ),
         "data": attr.label_list(allow_files = True),
+	"graal_extra_args": attr.string_list()
     },
     executable = True,
     fragments = ["cpp"],

--- a/graal/graal.bzl
+++ b/graal/graal.bzl
@@ -82,6 +82,10 @@ def _graal_binary_implementation(ctx):
         args.add("-H:ReflectionConfigurationFiles={path}".format(path=ctx.file.reflection_configuration.path))
         classpath_depset = depset([ctx.file.reflection_configuration], transitive=[classpath_depset])
 
+    if ctx.attr.jni_configuration != None:
+        args.add("-H:JNIConfigurationFiles={path}".format(path=ctx.file.jni_configuration.path))
+        classpath_depset = depset([ctx.file.jni_configuration], transitive=[classpath_depset])
+        args.add("-H:+JNI")
 
     ctx.actions.run(
         inputs = classpath_depset,
@@ -108,6 +112,7 @@ graal_binary = rule(
             allow_files = True,
         ),
         "reflection_configuration": attr.label(mandatory=False, allow_single_file=True),
+        "jni_configuration": attr.label(mandatory=False, allow_single_file=True),
         "main_class": attr.string(),
         "initialize_at_build_time": attr.string_list(),
         "native_image_features": attr.string_list(),


### PR DESCRIPTION
A hand full of tweeks, most of which aren't all that important, but some are super helpful

- pass `no-fallback` so that an unsupported feature fails the build instead of just creating a warning with a useless final image
- pass  `ReportExceptionStackTraces` for better debugging
- remove `outputs` param from rules since it is deprecated
- add the ability to have a jniconfig
- add the ability to pass arbitrary parameters (eg --enable-http)
- include `binary` in files so that it shows up in `location`