### PR TITLE
"deps" only accept JavaInfo labels

### DIFF
--- a/graal/graal.bzl
+++ b/graal/graal.bzl
@@ -19,7 +19,6 @@ def _graal_binary_implementation(ctx):
     classpath_depset = depset(transitive = [
         dep[JavaInfo].transitive_runtime_jars
         for dep in ctx.attr.deps
-        if JavaInfo in dep
     ])
 
     cc_toolchain = find_cpp_toolchain(ctx)
@@ -114,9 +113,7 @@ def _graal_binary_implementation(ctx):
 graal_binary = rule(
     implementation = _graal_binary_implementation,
     attrs = {
-        "deps": attr.label_list(
-            allow_files = True,
-        ),
+        "deps": attr.label_list(providers = [[JavaInfo]]),
         "reflection_configuration": attr.label(mandatory=False, allow_single_file=True),
         "jni_configuration": attr.label(mandatory=False, allow_single_file=True),
         "main_class": attr.string(),


### PR DESCRIPTION
previous `graal_binary` could accept non JavaInfo labels and files and would just ignore them silently.
This is a breaking change and you can completely ignore it but I thought there's value in being explicit than having users think it's working but then try to debug it.
