### PR TITLE
Fix: GraalVM `22.1.0`

### DIFF
--- a/graal/graal_bindist.bzl
+++ b/graal/graal_bindist.bzl
@@ -1,5 +1,6 @@
 _graal_archive_internal_prefixs = {
     "darwin-amd64": "graalvm-ce-java{java_version}-{version}/Contents/Home",
+    "darwin-aarch64": "graalvm-ce-java{java_version}-{version}/Contents/Home",
     "linux-amd64": "graalvm-ce-java{java_version}-{version}",
 }
 
@@ -209,6 +210,11 @@ def _get_platform(ctx):
         return "linux-%s" % arch
     elif ctx.os.name == "mac os x":
         if arch == "arm64" or arch == "aarch64":
+            if ctx.attr.version != "22.1.0":
+                fail(
+                    "GraalVM has `aarch64` distributions for macOS starting with v22.1.0. " +
+                    "Please upgrade or use `amd64`."
+                )
             return "darwin-aarch64"
         return "darwin-amd64"
     else:


### PR DESCRIPTION
This small fix adds `darwin-aarch64` to the internal prefix list, which was missed in my last PR. While I was there, I added a better error message for pre-`22.1.0` use of `aarch64` on macOS.

Changes enclosed:
- [x] Add `darwin-aarch64` to internal prefix list
- [x] Add better error message if using GVM < `21.3.0` on M1

@johnynek: my apologies, missed this dict at the top. this time it's tested against a repo locally using the new version, on M1. thanks again and you may see a PR from me soon to automate the bindist update process, now that Oracle is also shipping `.sha256` hashes with releases, which is awesome.