### PR TITLE
chore: add link to newer package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # rules_graal
 
+> [!WARNING]
+> This repository covers GraalVM releases up to the recent distribution change with Oracle GraalVM / GraalVM CE, and Bazel up to Bazel 6. If you need newer releases, try [`rules_graalvm`](https://github.com/sgammon/rules_graalvm).
+
 Turn a JVM binary into a native binary.
 
 ## Usage


### PR DESCRIPTION
## Summary

Hey party people. Obviously the distribution mechanism for GraalVM has shifted quite a bit recently, and so has the set of conventions and APIs it takes to ship a set of Bazel rules.

After keeping the releases up to date in this package for awhile, I felt a rewrite was needed to keep up with our changing world. [The new package](https://github.com/sgammon/rules_graalvm) supports several new features and is native to Bazel 6 / Bazel 7.

I've tried to maintain backwards compatibility (within the bounds of new conventions). Older versions of the SDK supported through this module are still available through the new package, but the focus will be on the newest GraalVM releases from Oracle and CE in that repo.

Of course, I'm a big fan of this package, having committed to it for quite awhile. But I fear our engagement with GraalVM is drifting from this package's support, and that @andyscott has better things to do than put up with a bunch of messy force-pushed PRs from me. So this PR is 100% optional,  but encouraged just to prevent confusion in the community.

If there is a total revolt over this PR and you guys would _strongly_ rather I keep these extensive changes _here_, in this repo, I'm open to discussing, but as you can tell I'm a little biased toward velocity at this time (just being honest).

**Features added in the new package:**

- Use of GraalVM as a Java toolchain
- Fetch components via `gu` transitively
- Support for Windows
- Support for Bzlmod, and soon a release to BCR
- Refreshed `native_image` rule
- Auto-fetch latest GraalVM SDK and provide your own SHA256
- Support for `target_compatible_with` and a full suite of arch-based SDK registrations (coming soon)
- Matches conventions of newer rules packages
- Compatibility guarantees via Bazel CI and Bzlmod
- Dedicated toolchain types for GraalVM, `native-image` (allows resolving alongside regular JVMs)

## Changelog

- add warning to `README` with link to newer package